### PR TITLE
Building for macos intel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
         
         strategy:
             matrix:
-              os: [macos-13]
+              os: [macos-13, macos-latest]
               #os: [macos-latest, ubuntu-latest, windows-latest]
         
         runs-on: "${{ matrix.os }}"
@@ -23,6 +23,13 @@ jobs:
               uses: actions/setup-python@v5
               with:
                 python-version: '3.11'
+                architecture: |
+                  ${{ 
+                    matrix.os == 'windows-latest' && 'x64'   || 
+                    matrix.os == 'ubuntu-latest'  && 'x64'   || 
+                    matrix.os == 'macos-13'       && 'x64'   || 
+                    matrix.os == 'macos-latest'   && 'arm64' 
+                  }}
                 cache: 'pip'
                 cache-dependency-path: |
                   **/requirements*.txt
@@ -46,7 +53,7 @@ jobs:
                   NMR-Fido-${{ 
                     matrix.os == 'windows-latest' && 'windows'     || 
                     matrix.os == 'ubuntu-latest'  && 'linux'       ||
-                    matrix.os == 'macos-latest'   && 'macos-intel' ||
+                    matrix.os == 'macos-13'       && 'macos-intel' ||
                     matrix.os == 'macos-latest'   && 'macos-m1'
                   }}
                 path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,7 @@ jobs:
         
         strategy:
             matrix:
-              os: [macos-13, macos-latest]
-              #os: [macos-latest, ubuntu-latest, windows-latest]
+              os: [macos-13, macos-latest, ubuntu-latest, windows-latest]
         
         runs-on: "${{ matrix.os }}"
         
@@ -45,6 +44,7 @@ jobs:
                 script-name: NMR-Fido.py
                 mode: app
                 enable-plugins: pyside6
+                deployment:
             
             - name: Upload artifacts
               uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
                 script-name: NMR-Fido.py
                 mode: app
                 enable-plugins: pyside6
-                deployment:
+                deployment: true
             
             - name: Upload artifacts
               uses: actions/upload-artifact@v4


### PR DESCRIPTION
Opening the app compiled on macos-latest gives "App is damaged and can't be opened" on intel macs. The adapted workflow creates an artifact specifically for intel macs.